### PR TITLE
removed superfluous hashmap lib

### DIFF
--- a/lib/rolling-window-throttler.js
+++ b/lib/rolling-window-throttler.js
@@ -1,6 +1,5 @@
 'use strict';
-const HashMap = require('hashmap'),
-  parseDuration = require('parse-duration'),
+const parseDuration = require('parse-duration'),
   clock = require('./clock');
 
 module.exports.get = options => new RollingWindowThrottler(options);
@@ -10,7 +9,7 @@ class RollingWindowThrottler{
     this.max = options.max;
     this.durationWindow = this._calculateDuration(options.durationWindow);
     this.clock = options.clock || clock();
-    this.invocations = new HashMap();
+    this.invocations = {}
   }
 
 
@@ -18,7 +17,7 @@ class RollingWindowThrottler{
     const invocation = this._getOrElseCreate(key);
     this._incrementInvocationCount(invocation);
     if(this._isExpires(invocation)){
-      this.invocations.remove(key);
+      delete this.invocations[key];
       return this.tryAcquire(key);
     }
     return invocation.count <= this.max;
@@ -29,10 +28,8 @@ class RollingWindowThrottler{
   }
 
   _getOrElseCreate(key){
-    if(!this.invocations.has(key)){
-      this.invocations.set(key, this._newInvocation());
-    }
-    return this.invocations.get(key);
+    return this.invocations[key] 
+      || (this.invocations[key] = this._newInvocation(), this.invocations[key]);
   }
 
   _newInvocation(){
@@ -41,7 +38,7 @@ class RollingWindowThrottler{
   }
 
   _incrementInvocationCount(invocation){
-    invocation.count = invocation.count + 1;
+    invocation.count++;
   }
 
   _calculateDuration(durationWindow){


### PR DESCRIPTION
JS developers don't like forced Java semantics. I removed the `hashmap` library, which you weren't really making any special usage of, and replaced with with plain object semantics.